### PR TITLE
Create Swift gaze tracking workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
+      - name: Resolve dependencies
+        run: swift package resolve
+      - name: Build
+        run: swift build --build-tests
+      - name: Test
+        run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,40 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "EyeTrackerSuite",
+    defaultLocalization: "en",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14)
+    ],
+    products: [
+        .library(name: "GazeTrackingKit", targets: ["GazeTrackingKit"]),
+        .library(name: "GazeUI", targets: ["GazeUI"]),
+        .executable(name: "GazeLabPreviewer", targets: ["GazeLabPreviewer"])
+    ],
+    targets: [
+        .target(
+            name: "GazeTrackingKit"
+        ),
+        .target(
+            name: "GazeUI",
+            dependencies: [
+                "GazeTrackingKit"
+            ]
+        ),
+        .executableTarget(
+            name: "GazeLabPreviewer",
+            dependencies: ["GazeUI", "GazeTrackingKit"],
+            path: "Sources/GazeLabPreviewer"
+        ),
+        .testTarget(
+            name: "GazeTrackingKitTests",
+            dependencies: ["GazeTrackingKit"]
+        ),
+        .testTarget(
+            name: "GazeUITests",
+            dependencies: ["GazeUI", "GazeTrackingKit"]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,77 @@
-Readme for test eyetracking app.
+# EyeTracker Suite
+
+EyeTracker Suite is a Swift Package-based workspace that showcases an on-device gaze tracking pipeline with reusable components for iOS and macOS prototypes. It includes:
+
+- **GazeTrackingKit**: capture providers, calibration logic, smoothing filters, heatmap/trail renderers, and session coordination.
+- **GazeUI**: cross-platform SwiftUI views for live gaze visualization, calibration, metrics, and exports.
+- **GazeLabPreviewer**: a lightweight SwiftUI app target demonstrating the dashboard in action.
+
+> **Privacy-first design** – all processing runs locally. No network connections are performed and the default camera providers only operate while the previewer is in the foreground.
+
+## Repository layout
+
+```
+.
+├── Package.swift
+├── README.md
+├── Sources
+│   ├── GazeLabPreviewer        # SwiftUI demo app entry point
+│   ├── GazeTrackingKit         # Core gaze tracking pipeline
+│   └── GazeUI                  # SwiftUI components
+└── Tests
+    ├── GazeTrackingKitTests
+    └── GazeUITests
+```
+
+## Getting started
+
+1. Install the latest Xcode (15.1+) on macOS 14.
+2. Open the package in Xcode:
+   ```bash
+   open Package.swift
+   ```
+3. Select the **GazeLabPreviewer** scheme and run on either the macOS host (My Mac) or an iOS 17 simulator with a TrueDepth-capable device profile (e.g., iPhone 14 Pro).
+4. Grant camera access when prompted. On macOS, Screen Recording/Accessibility permissions are only required when integrating with a custom overlay host; the sample app itself does not request them.
+
+### Calibration workflow
+
+1. Switch to the **Calibrate** tab.
+2. Tap **Start** to walk through a 9-point calibration routine. Each fixation is sampled for ~400 ms.
+3. Tap **Finish** to fit a ridge-regularized quadratic mapping. Metrics appear in the **Metrics** tab.
+
+### Heatmap & trails controls
+
+- Heatmap and trail overlays can be toggled directly from the Live view.
+- The heatmap renders into a 96×54 grid with Gaussian blur and exponential decay. Trails keep ~3.5 s of data.
+
+### Data export
+
+Use `GazeViewModel.exportSamples(_:url:)` to export CSV/JSON payloads from app code. The demo surfaces JSON by default.
+
+## Testing
+
+Run the included unit test suite with:
+
+```bash
+swift test
+```
+
+## Continuous Integration
+
+A GitHub Actions workflow (`.github/workflows/ci.yml`) is provided to build the package and execute tests on macOS runners.
+
+## Known limitations
+
+- The previewer implements the full gaze pipeline but omits the production menubar overlay target. Integrate `GazeTrackingKit` into a dedicated macOS app to extend functionality.
+- ARKit eye tracking requires TrueDepth hardware and is only available on supported devices/simulators.
+- System-wide overlays are not supported on iOS due to platform limitations; gaze rendering remains inside the host window.
+
+## Privacy
+
+- All computation and storage happen locally. No analytics or network communication.
+- Camera frames are processed in-memory; no frames are persisted.
+- A single “Start/Stop” toggle immediately pauses both capture and rendering.
+
+## License
+
+This repository is provided for demonstration and educational use. Review and adapt for production deployments as needed.

--- a/Sources/GazeLabPreviewer/main.swift
+++ b/Sources/GazeLabPreviewer/main.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import GazeUI
+
+@main
+struct GazeLabPreviewerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            GazeDashboard()
+        }
+        #if os(macOS)
+        .windowStyle(.automatic)
+        #endif
+    }
+}

--- a/Sources/GazeTrackingKit/Calibration/CalibrationManager.swift
+++ b/Sources/GazeTrackingKit/Calibration/CalibrationManager.swift
@@ -1,0 +1,159 @@
+import Combine
+import CoreGraphics
+import Foundation
+
+public final class CalibrationManager: ObservableObject {
+    @Published public private(set) var points: [CalibrationPoint]
+    @Published public private(set) var isCalibrating: Bool = false
+    @Published public private(set) var progress: Double = 0
+    @Published public private(set) var lastResult: GazeCalibrationResult?
+
+    private var cancellables = Set<AnyCancellable>()
+    private var capturedSamples: [SIMD8<Double>] = []
+    private var capturedTargets: [CGPoint] = []
+    private let regressor = PolynomialRegressor()
+    private let samplingQueue = DispatchQueue(label: "com.eyetracker.calibration")
+
+    public init(points: [CalibrationPoint] = CalibrationManager.defaultPoints()) {
+        self.points = points
+    }
+
+    public func updatePoints(count: Int) {
+        points = CalibrationManager.generatePoints(count: count)
+    }
+
+    public func beginCalibration(using publisher: AnyPublisher<GazeSample, Never>) {
+        guard !isCalibrating else { return }
+        isCalibrating = true
+        progress = 0
+        capturedSamples = []
+        capturedTargets = []
+        let total = Double(points.count)
+        var currentIndex = 0
+        publisher
+            .receive(on: samplingQueue)
+            .prefix(points.count * 300)
+            .sink { [weak self] sample in
+                guard let self else { return }
+                guard currentIndex < self.points.count else { return }
+                let target = self.points[currentIndex]
+                self.capturedSamples.append(sample.features)
+                self.capturedTargets.append(target.target)
+                let fraction = Double(self.capturedSamples.count) / (total * 300.0)
+                DispatchQueue.main.async {
+                    self.progress = min(fraction, 1.0)
+                }
+                if self.capturedSamples.count % 300 == 0 {
+                    currentIndex += 1
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    public func finishCalibration() {
+        samplingQueue.async { [weak self] in
+            guard let self else { return }
+            do {
+                let (wx, wy, featureCount) = try self.regressor.fit(inputs: self.capturedSamples, outputs: self.capturedTargets)
+                let predictions = zip(self.capturedSamples, self.capturedTargets).map { features, target -> (CGPoint, CGPoint) in
+                    let predicted = self.predict(features: features, weightsX: wx, weightsY: wy)
+                    return (predicted, target)
+                }
+                let errors = predictions.map { hypot(Double($0.0.x - $0.1.x), Double($0.0.y - $0.1.y)) }
+                let median = CalibrationManager.percentile(values: errors, q: 0.5)
+                let percentile95 = CalibrationManager.percentile(values: errors, q: 0.95)
+                let rms = sqrt(errors.reduce(0) { $0 + $1 * $1 } / Double(max(errors.count, 1)))
+                let result = GazeCalibrationResult(
+                    coefficients: wx + wy,
+                    regularization: regressor.regularization,
+                    featureDimension: featureCount,
+                    rmsError: rms,
+                    medianError: median,
+                    percentile95Error: percentile95
+                )
+                DispatchQueue.main.async {
+                    self.lastResult = result
+                    self.isCalibrating = false
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self.isCalibrating = false
+                }
+            }
+        }
+    }
+
+    public func predictPoint(for sample: GazeSample) -> CGPoint? {
+        guard let result = lastResult else { return nil }
+        let count = result.featureDimension
+        let weightsX = Array(result.coefficients.prefix(count))
+        let weightsY = Array(result.coefficients.suffix(count))
+        return predict(features: sample.features, weightsX: weightsX, weightsY: weightsY)
+    }
+
+    private func predict(features: SIMD8<Double>, weightsX: [Double], weightsY: [Double]) -> CGPoint {
+        let vector = regressor.designVector(from: features)
+        let x = zip(vector, weightsX).reduce(0) { $0 + $1.0 * $1.1 }
+        let y = zip(vector, weightsY).reduce(0) { $0 + $1.0 * $1.1 }
+        return CGPoint(x: x, y: y)
+    }
+
+    public func computeStatistics(samples: [GazeSample], targets: [CGPoint]) -> GazeStatistics {
+        let paired = zip(samples, targets)
+        let predictions = paired.compactMap { sample, target -> (CGPoint, CGPoint)? in
+            guard let predicted = predictPoint(for: sample) else { return nil }
+            return (predicted, target)
+        }
+        let errors = predictions.map { hypot(Double($0.0.x - $0.1.x), Double($0.0.y - $0.1.y)) }
+        let angularErrors = predictions.map { error -> Double in
+            let distance = hypot(Double(error.1.x - 0.5), Double(error.1.y - 0.5))
+            return atan2(distance, 0.6) * (180.0 / .pi)
+        }
+        return GazeStatistics(
+            samples: predictions.count,
+            medianError: CalibrationManager.percentile(values: errors, q: 0.5),
+            percentile95Error: CalibrationManager.percentile(values: errors, q: 0.95),
+            rms: sqrt(errors.reduce(0) { $0 + $1 * $1 } / Double(max(errors.count, 1))),
+            angularMedian: CalibrationManager.percentile(values: angularErrors, q: 0.5),
+            angular95: CalibrationManager.percentile(values: angularErrors, q: 0.95)
+        )
+    }
+
+    public static func defaultPoints() -> [CalibrationPoint] {
+        return generatePoints(count: 9)
+    }
+
+    public static func generatePoints(count: Int) -> [CalibrationPoint] {
+        let templates: [[CGPoint]] = [
+            [
+                CGPoint(x: 0.5, y: 0.5),
+                CGPoint(x: 0.1, y: 0.1),
+                CGPoint(x: 0.9, y: 0.1),
+                CGPoint(x: 0.1, y: 0.9),
+                CGPoint(x: 0.9, y: 0.9)
+            ],
+            [
+                CGPoint(x: 0.1, y: 0.1), CGPoint(x: 0.5, y: 0.1), CGPoint(x: 0.9, y: 0.1),
+                CGPoint(x: 0.1, y: 0.5), CGPoint(x: 0.5, y: 0.5), CGPoint(x: 0.9, y: 0.5),
+                CGPoint(x: 0.1, y: 0.9), CGPoint(x: 0.5, y: 0.9), CGPoint(x: 0.9, y: 0.9)
+            ]
+        ]
+        let chosen: [CGPoint]
+        switch count {
+        case ..<5:
+            chosen = Array(templates[0].prefix(max(count, 1)))
+        case 5:
+            chosen = templates[0]
+        default:
+            chosen = templates[1]
+        }
+        return chosen.enumerated().map { CalibrationPoint(id: $0.offset, target: $0.element) }
+    }
+
+    private static func percentile(values: [Double], q: Double) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let index = min(max(Int(Double(sorted.count - 1) * q), 0), sorted.count - 1)
+        return sorted[index]
+    }
+}

--- a/Sources/GazeTrackingKit/Calibration/PolynomialRegressor.swift
+++ b/Sources/GazeTrackingKit/Calibration/PolynomialRegressor.swift
@@ -1,0 +1,109 @@
+import Accelerate
+import Foundation
+
+struct PolynomialRegressor {
+    let degree: Int
+    let regularization: Double
+
+    init(degree: Int = 2, regularization: Double = 1e-4) {
+        self.degree = degree
+        self.regularization = regularization
+    }
+
+    func designVector(from features: SIMD8<Double>) -> [Double] {
+        var vector: [Double] = [1.0]
+        for i in 0..<features.scalarCount {
+            vector.append(features[i])
+        }
+        if degree >= 2 {
+            for i in 0..<features.scalarCount {
+                for j in i..<features.scalarCount {
+                    vector.append(features[i] * features[j])
+                }
+            }
+        }
+        return vector
+    }
+
+    func fit(inputs: [SIMD8<Double>], outputs: [CGPoint]) throws -> (weightsX: [Double], weightsY: [Double], featureCount: Int) {
+        let design = inputs.map(designVector)
+        guard let first = design.first else {
+            throw GazeError.insufficientSamples
+        }
+        let rows = design.count
+        let cols = first.count
+        var matrix = Matrix(rows: rows, columns: cols)
+        for r in 0..<rows {
+            for c in 0..<cols {
+                matrix[r, c] = design[r][c]
+            }
+        }
+        var targetX = outputs.map { Double($0.x) }
+        var targetY = outputs.map { Double($0.y) }
+        var weightsX = [Double](repeating: 0, count: cols)
+        var weightsY = [Double](repeating: 0, count: cols)
+        try solveRidge(matrix: matrix, target: &targetX, weights: &weightsX)
+        try solveRidge(matrix: matrix, target: &targetY, weights: &weightsY)
+        return (weightsX, weightsY, cols)
+    }
+
+    private func solveRidge(matrix: Matrix, target: inout [Double], weights: inout [Double]) throws {
+        var ata = matrix.transpose.multiply(by: matrix)
+        for i in 0..<ata.rows {
+            ata[i, i] += regularization
+        }
+        var atb = matrix.transpose.multiply(vector: target)
+        var pivot = [__CLPK_integer](repeating: 0, count: ata.rows)
+        var n = __CLPK_integer(ata.rows)
+        var nrhs = __CLPK_integer(1)
+        var lda = n
+        var ldb = n
+        var info: __CLPK_integer = 0
+        dgesv_(&n, &nrhs, &ata.elements, &lda, &pivot, &atb, &ldb, &info)
+        guard info == 0 else {
+            throw GazeError.regressionFailure
+        }
+        weights = atb
+    }
+}
+
+struct Matrix {
+    let rows: Int
+    let columns: Int
+    var elements: [Double]
+
+    init(rows: Int, columns: Int) {
+        self.rows = rows
+        self.columns = columns
+        self.elements = [Double](repeating: 0, count: rows * columns)
+    }
+
+    subscript(row: Int, column: Int) -> Double {
+        get { elements[row * columns + column] }
+        set { elements[row * columns + column] = newValue }
+    }
+
+    var transpose: Matrix {
+        var result = Matrix(rows: columns, columns: rows)
+        for r in 0..<rows {
+            for c in 0..<columns {
+                result[c, r] = self[r, c]
+            }
+        }
+        return result
+    }
+
+    func multiply(by other: Matrix) -> Matrix {
+        precondition(columns == other.rows)
+        var result = Matrix(rows: rows, columns: other.columns)
+        vDSP_mmulD(elements, 1, other.elements, 1, &result.elements, 1, vDSP_Length(rows), vDSP_Length(other.columns), vDSP_Length(columns))
+        return result
+    }
+
+    func multiply(vector: [Double]) -> [Double] {
+        precondition(columns == vector.count)
+        var result = [Double](repeating: 0, count: rows)
+        vDSP_mmulD(elements, 1, vector, 1, &result, 1, vDSP_Length(rows), 1, vDSP_Length(columns))
+        return result
+    }
+}

--- a/Sources/GazeTrackingKit/Filters/OneEuroFilter.swift
+++ b/Sources/GazeTrackingKit/Filters/OneEuroFilter.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+public final class OneEuroFilter: @unchecked Sendable {
+    public var minCutoff: Double
+    public var beta: Double
+    public var dCutoff: Double
+    private var lastTime: TimeInterval?
+    private var xPrev: Double?
+    private var dxPrev: Double?
+
+    public init(minCutoff: Double = 1.0, beta: Double = 0.007, dCutoff: Double = 1.0) {
+        self.minCutoff = minCutoff
+        self.beta = beta
+        self.dCutoff = dCutoff
+    }
+
+    public func reset() {
+        lastTime = nil
+        xPrev = nil
+        dxPrev = nil
+    }
+
+    public func filter(value: Double, timestamp: TimeInterval) -> Double {
+        guard let lastTime else {
+            lastTime = timestamp
+            xPrev = value
+            dxPrev = 0
+            return value
+        }
+        let dt = max(timestamp - lastTime, 1.0 / 120.0)
+        let dx = (xPrev.map { (value - $0) / dt } ?? 0)
+        let alphaD = smoothingFactor(dt: dt, cutoff: dCutoff)
+        let dxHat = exponentialSmoothing(alpha: alphaD, value: dx, previous: dxPrev)
+        let cutoff = minCutoff + beta * abs(dxHat)
+        let alpha = smoothingFactor(dt: dt, cutoff: cutoff)
+        let xHat = exponentialSmoothing(alpha: alpha, value: value, previous: xPrev)
+        self.lastTime = timestamp
+        self.xPrev = xHat
+        self.dxPrev = dxHat
+        return xHat
+    }
+
+    private func smoothingFactor(dt: Double, cutoff: Double) -> Double {
+        let r = 2 * Double.pi * cutoff * dt
+        return r / (r + 1)
+    }
+
+    private func exponentialSmoothing(alpha: Double, value: Double, previous: Double?) -> Double {
+        guard let previous else { return value }
+        return alpha * value + (1 - alpha) * previous
+    }
+}

--- a/Sources/GazeTrackingKit/Filters/RobustOutlierFilter.swift
+++ b/Sources/GazeTrackingKit/Filters/RobustOutlierFilter.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public struct RobustOutlierFilter: Sendable {
+    public var threshold: Double
+    public var windowSize: Int
+    private var values: [Double] = []
+
+    public init(threshold: Double = 3.5, windowSize: Int = 120) {
+        self.threshold = threshold
+        self.windowSize = max(1, windowSize)
+    }
+
+    public mutating func evaluate(value: Double) -> Bool {
+        values.append(value)
+        if values.count > windowSize {
+            values.removeFirst(values.count - windowSize)
+        }
+        guard values.count >= 5 else { return true }
+        let median = percentile(values: values, q: 0.5)
+        let deviations = values.map { abs($0 - median) }
+        let mad = percentile(values: deviations, q: 0.5) * 1.4826
+        guard mad > .ulpOfOne else { return true }
+        let modifiedZ = abs(value - median) / mad
+        return modifiedZ <= threshold
+    }
+
+    private func percentile(values: [Double], q: Double) -> Double {
+        let sorted = values.sorted()
+        let index = min(max(Int(Double(sorted.count - 1) * q), 0), sorted.count - 1)
+        return sorted[index]
+    }
+}

--- a/Sources/GazeTrackingKit/Heatmap/HeatmapRenderer.swift
+++ b/Sources/GazeTrackingKit/Heatmap/HeatmapRenderer.swift
@@ -1,0 +1,146 @@
+import CoreGraphics
+import Foundation
+
+#if canImport(Metal)
+import CoreImage
+import Metal
+import MetalPerformanceShaders
+
+public final class HeatmapRenderer: ObservableObject {
+    public struct Configuration: Sendable {
+        public var width: Int
+        public var height: Int
+        public var decay: Double
+        public var blurRadius: Double
+
+        public init(width: Int = 96, height: Int = 54, decay: Double = 0.92, blurRadius: Double = 8.0) {
+            self.width = width
+            self.height = height
+            self.decay = decay
+            self.blurRadius = blurRadius
+        }
+    }
+
+    @Published public private(set) var image: CGImage?
+
+    private let device: MTLDevice
+    private let commandQueue: MTLCommandQueue
+    private var texture: MTLTexture
+    private var configuration: Configuration
+    private let colorMap = TurboColorMap()
+
+    public init?(device: MTLDevice? = MTLCreateSystemDefaultDevice(), configuration: Configuration = Configuration()) {
+        guard let device, let commandQueue = device.makeCommandQueue() else {
+            return nil
+        }
+        self.device = device
+        self.commandQueue = commandQueue
+        self.configuration = configuration
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r32Float, width: configuration.width, height: configuration.height, mipmapped: false)
+        descriptor.usage = [.shaderRead, .shaderWrite]
+        guard let texture = device.makeTexture(descriptor: descriptor) else { return nil }
+        self.texture = texture
+    }
+
+    public func reset() {
+        let region = MTLRegionMake2D(0, 0, configuration.width, configuration.height)
+        var zeros = [Float](repeating: 0, count: configuration.width * configuration.height)
+        texture.replace(region: region, mipmapLevel: 0, withBytes: &zeros, bytesPerRow: configuration.width * MemoryLayout<Float>.size)
+    }
+
+    public func addSample(_ point: CGPoint, weight: Float = 1.0) {
+        guard point.x.isFinite, point.y.isFinite else { return }
+        let x = Int((point.x.clamped(to: 0...1)) * CGFloat(configuration.width - 1))
+        let y = Int((point.y.clamped(to: 0...1)) * CGFloat(configuration.height - 1))
+        let region = MTLRegionMake2D(x, y, 1, 1)
+        var existing = Float(0)
+        texture.getBytes(&existing, bytesPerRow: MemoryLayout<Float>.size, from: region, mipmapLevel: 0)
+        var updated = existing * Float(configuration.decay) + weight
+        texture.replace(region: region, mipmapLevel: 0, withBytes: &updated, bytesPerRow: MemoryLayout<Float>.size)
+    }
+
+    public func updateImage() {
+        guard let commandBuffer = commandQueue.makeCommandBuffer() else { return }
+        let gaussian = MPSImageGaussianBlur(device: device, sigma: Float(configuration.blurRadius))
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r32Float, width: configuration.width, height: configuration.height, mipmapped: false)
+        descriptor.usage = [.shaderWrite, .shaderRead]
+        guard let output = device.makeTexture(descriptor: descriptor) else { return }
+        gaussian.encode(commandBuffer: commandBuffer, sourceTexture: texture, destinationTexture: output)
+        commandBuffer.addCompletedHandler { [weak self] _ in
+            self?.generateImage(from: output)
+        }
+        commandBuffer.commit()
+    }
+
+    public func gridValues() -> [[Float]] {
+        let region = MTLRegionMake2D(0, 0, configuration.width, configuration.height)
+        var data = [Float](repeating: 0, count: configuration.width * configuration.height)
+        texture.getBytes(&data, bytesPerRow: configuration.width * MemoryLayout<Float>.size, from: region, mipmapLevel: 0)
+        var grid: [[Float]] = []
+        for y in 0..<configuration.height {
+            let start = y * configuration.width
+            let row = Array(data[start..<(start + configuration.width)])
+            grid.append(row)
+        }
+        return grid
+    }
+
+    private func generateImage(from texture: MTLTexture) {
+        let width = texture.width
+        let height = texture.height
+        let count = width * height
+        var data = [Float](repeating: 0, count: count)
+        let region = MTLRegionMake2D(0, 0, width, height)
+        texture.getBytes(&data, bytesPerRow: width * MemoryLayout<Float>.size, from: region, mipmapLevel: 0)
+        let maxValue = data.max() ?? 1
+        var rgba = [UInt8](repeating: 0, count: count * 4)
+        for i in 0..<count {
+            let normalized = maxValue > 0 ? min(data[i] / maxValue, 1) : 0
+            let color = colorMap.color(for: normalized)
+            rgba[i * 4 + 0] = color.red
+            rgba[i * 4 + 1] = color.green
+            rgba[i * 4 + 2] = color.blue
+            rgba[i * 4 + 3] = UInt8(normalized * 255)
+        }
+        let provider = CGDataProvider(data: Data(rgba) as CFData)!
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        image = CGImage(width: width, height: height, bitsPerComponent: 8, bitsPerPixel: 32, bytesPerRow: width * 4, space: colorSpace, bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.last.rawValue), provider: provider, decode: nil, shouldInterpolate: true, intent: .defaultIntent)
+    }
+}
+#else
+
+public final class HeatmapRenderer: ObservableObject {
+    public struct Configuration: Sendable {
+        public init(width: Int = 96, height: Int = 54, decay: Double = 0.92, blurRadius: Double = 8.0) {}
+    }
+
+    @Published public private(set) var image: CGImage?
+
+    public init?(device: Any? = nil, configuration: Configuration = Configuration()) {
+        return nil
+    }
+
+    public func reset() {}
+    public func addSample(_ point: CGPoint, weight: Float = 1.0) {}
+    public func updateImage() {}
+    public func gridValues() -> [[Float]] { [] }
+}
+#endif
+
+private struct TurboColorMap {
+    struct RGB { let red: UInt8; let green: UInt8; let blue: UInt8 }
+
+    func color(for value: Float) -> RGB {
+        let clamped = max(0, min(1, value))
+        let r = UInt8(255 * pow(clamped, 0.5))
+        let g = UInt8(255 * sin(clamped * .pi * 0.5))
+        let b = UInt8(255 * (1 - clamped * 0.8))
+        return RGB(red: r, green: g, blue: b)
+    }
+}
+
+private extension CGFloat {
+    func clamped(to range: ClosedRange<CGFloat>) -> CGFloat {
+        return min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/Sources/GazeTrackingKit/Providers/ARFaceTrackingProvider.swift
+++ b/Sources/GazeTrackingKit/Providers/ARFaceTrackingProvider.swift
@@ -1,0 +1,70 @@
+#if canImport(ARKit)
+import ARKit
+import Combine
+import CoreGraphics
+import Foundation
+
+final class ARFaceTrackingProvider: NSObject, GazeProvider, ARSessionDelegate {
+    private let session = ARSession()
+    private let subject = PassthroughSubject<GazeSample, Never>()
+    private let queue = DispatchQueue(label: "com.eyetracker.arprovider")
+
+    override init() {
+        super.init()
+        session.delegate = self
+    }
+
+    var samples: AnyPublisher<GazeSample, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    func start() {
+        guard ARFaceTrackingConfiguration.isSupported else {
+            return
+        }
+        let configuration = ARFaceTrackingConfiguration()
+        configuration.isWorldTrackingEnabled = false
+        configuration.maximumNumberOfTrackedFaces = 1
+        session.run(configuration, options: [.resetTracking, .removeExistingAnchors])
+    }
+
+    func stop() {
+        session.pause()
+    }
+
+    func session(_ session: ARSession, didUpdate anchors: [ARAnchor]) {
+        queue.async { [weak self] in
+            anchors.compactMap { $0 as? ARFaceAnchor }.forEach { anchor in
+                self?.emitSample(from: anchor)
+            }
+        }
+    }
+
+    private func emitSample(from anchor: ARFaceAnchor) {
+        let transform = anchor.transform
+        let origin = simd_make_float3(transform.columns.3)
+        let lookAt = anchor.lookAtPoint
+        let direction = simd_normalize(lookAt - origin)
+        let projected = CGPoint(x: CGFloat(direction.x), y: CGFloat(direction.y))
+        let features = SIMD8<Double>(
+            Double(direction.x),
+            Double(direction.y),
+            Double(direction.z),
+            Double(anchor.blendShapes[.eyeBlinkLeft]?.doubleValue ?? 0),
+            Double(anchor.blendShapes[.eyeBlinkRight]?.doubleValue ?? 0),
+            Double(anchor.leftEyeTransform.columns.3.x),
+            Double(anchor.rightEyeTransform.columns.3.x),
+            Double(anchor.lookAtPoint.z)
+        )
+        let sample = GazeSample(
+            timestamp: anchor.timestamp,
+            viewPoint: projected,
+            screenPoint: nil,
+            features: features,
+            validity: .valid,
+            eyeOpenness: 1.0 - Double(anchor.blendShapes[.eyeBlinkLeft]?.doubleValue ?? 0)
+        )
+        subject.send(sample)
+    }
+}
+#endif

--- a/Sources/GazeTrackingKit/Providers/GazeProvider.swift
+++ b/Sources/GazeTrackingKit/Providers/GazeProvider.swift
@@ -1,0 +1,34 @@
+import Combine
+import Foundation
+#if canImport(ARKit)
+import ARKit
+#endif
+#if canImport(Vision)
+import Vision
+#endif
+
+public protocol GazeProvider: AnyObject {
+    var samples: AnyPublisher<GazeSample, Never> { get }
+    func start()
+    func stop()
+}
+
+public enum GazeProviderConfiguration: Sendable {
+    case arFaceTracking
+    case visionLandmarks
+}
+
+public final class GazeProviderFactory {
+    public static func makeProvider(configuration: GazeProviderConfiguration) -> GazeProvider {
+        switch configuration {
+        case .arFaceTracking:
+            #if canImport(ARKit)
+            return ARFaceTrackingProvider()
+            #else
+            return VisionGazeProvider()
+            #endif
+        case .visionLandmarks:
+            return VisionGazeProvider()
+        }
+    }
+}

--- a/Sources/GazeTrackingKit/Providers/VisionGazeProvider.swift
+++ b/Sources/GazeTrackingKit/Providers/VisionGazeProvider.swift
@@ -1,0 +1,122 @@
+import Combine
+import CoreGraphics
+import CoreImage
+import CoreMedia
+import CoreVideo
+import Foundation
+#if canImport(AVFoundation)
+import AVFoundation
+#endif
+#if canImport(Vision)
+import Vision
+#endif
+
+final class VisionGazeProvider: NSObject, GazeProvider {
+    private let subject = PassthroughSubject<GazeSample, Never>()
+    private let sessionQueue = DispatchQueue(label: "com.eyetracker.visionprovider")
+    #if canImport(AVFoundation)
+    private let captureSession = AVCaptureSession()
+    private let videoOutput = AVCaptureVideoDataOutput()
+    #endif
+
+    override init() {
+        super.init()
+        #if canImport(AVFoundation)
+        configureSession()
+        #endif
+    }
+
+    var samples: AnyPublisher<GazeSample, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    func start() {
+        #if canImport(AVFoundation)
+        if !captureSession.isRunning {
+            captureSession.startRunning()
+        }
+        #endif
+    }
+
+    func stop() {
+        #if canImport(AVFoundation)
+        captureSession.stopRunning()
+        #endif
+    }
+
+    #if canImport(AVFoundation)
+    private func configureSession() {
+        captureSession.beginConfiguration()
+        captureSession.sessionPreset = .vga640x480
+        if let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .front),
+           let input = try? AVCaptureDeviceInput(device: device),
+           captureSession.canAddInput(input) {
+            captureSession.addInput(input)
+        }
+        videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
+        videoOutput.setSampleBufferDelegate(self, queue: sessionQueue)
+        if captureSession.canAddOutput(videoOutput) {
+            captureSession.addOutput(videoOutput)
+        }
+        captureSession.commitConfiguration()
+    }
+    #endif
+}
+
+#if canImport(AVFoundation) && canImport(Vision)
+extension VisionGazeProvider: AVCaptureVideoDataOutputSampleBufferDelegate {
+    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+        guard let buffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+        let request = VNDetectFaceLandmarksRequest { [weak self] request, error in
+            guard error == nil else { return }
+            guard let results = request.results as? [VNFaceObservation] else { return }
+            let timestamp = CMSampleBufferGetPresentationTimeStamp(sampleBuffer).seconds
+            for observation in results {
+                self?.process(observation: observation, timestamp: timestamp)
+            }
+        }
+        let handler = VNImageRequestHandler(cvPixelBuffer: buffer, orientation: .leftMirrored)
+        try? handler.perform([request])
+    }
+
+    private func process(observation: VNFaceObservation, timestamp: TimeInterval) {
+        guard let landmarks = observation.landmarks,
+              let leftPupil = landmarks.leftPupil,
+              let rightPupil = landmarks.rightPupil else { return }
+        let left = centroid(of: leftPupil)
+        let right = centroid(of: rightPupil)
+        let features = SIMD8<Double>(
+            Double(left.x),
+            Double(left.y),
+            Double(right.x),
+            Double(right.y),
+            Double(observation.boundingBox.midX),
+            Double(observation.boundingBox.midY),
+            Double(observation.roll?.doubleValue ?? 0),
+            Double(observation.yaw?.doubleValue ?? 0)
+        )
+        let viewPoint = CGPoint(x: CGFloat((left.x + right.x) * 0.5), y: CGFloat((left.y + right.y) * 0.5))
+        let sample = GazeSample(
+            timestamp: timestamp,
+            viewPoint: viewPoint,
+            screenPoint: nil,
+            features: features,
+            validity: .limited,
+            eyeOpenness: 1.0
+        )
+        subject.send(sample)
+    }
+
+    private func centroid(of region: VNFaceLandmarkRegion2D) -> CGPoint {
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        for i in 0..<region.pointCount {
+            let point = region.normalizedPoints[i]
+            x += CGFloat(point.x)
+            y += CGFloat(point.y)
+        }
+        let count = CGFloat(region.pointCount)
+        return CGPoint(x: x / count, y: y / count)
+    }
+}
+#endif

--- a/Sources/GazeTrackingKit/Support/GazeSession.swift
+++ b/Sources/GazeTrackingKit/Support/GazeSession.swift
@@ -1,0 +1,70 @@
+import Combine
+import CoreGraphics
+import Foundation
+
+public final class GazeSession: ObservableObject {
+    @Published public private(set) var latestSample: GazeSample?
+
+    public let heatmap: HeatmapRenderer?
+    public let trails: TrailRenderer
+    public let calibration: CalibrationManager
+    public var samplePublisher: AnyPublisher<GazeSample, Never> {
+        sampleSubject.eraseToAnyPublisher()
+    }
+
+    private let provider: GazeProvider
+    private var cancellables = Set<AnyCancellable>()
+    private var outlierFilterX = RobustOutlierFilter()
+    private var outlierFilterY = RobustOutlierFilter()
+    private var filterX = OneEuroFilter()
+    private var filterY = OneEuroFilter()
+    private let sampleSubject = PassthroughSubject<GazeSample, Never>()
+
+    public init(provider: GazeProvider = GazeProviderFactory.makeProvider(configuration: .visionLandmarks),
+                heatmap: HeatmapRenderer? = HeatmapRenderer(),
+                trails: TrailRenderer = TrailRenderer(),
+                calibration: CalibrationManager = CalibrationManager()) {
+        self.provider = provider
+        self.heatmap = heatmap
+        self.trails = trails
+        self.calibration = calibration
+        bind()
+    }
+
+    private func bind() {
+        provider.samples
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
+            .filter { [weak self] sample in
+                guard let self else { return false }
+                let okX = self.outlierFilterX.evaluate(value: Double(sample.viewPoint.x))
+                let okY = self.outlierFilterY.evaluate(value: Double(sample.viewPoint.y))
+                return okX && okY
+            }
+            .map { [weak self] sample -> GazeSample in
+                guard let self else { return sample }
+                let filteredX = self.filterX.filter(value: Double(sample.viewPoint.x), timestamp: sample.timestamp)
+                let filteredY = self.filterY.filter(value: Double(sample.viewPoint.y), timestamp: sample.timestamp)
+                let point = CGPoint(x: filteredX, y: filteredY)
+                return GazeSample(timestamp: sample.timestamp, viewPoint: point, screenPoint: sample.screenPoint, features: sample.features, validity: sample.validity, eyeOpenness: sample.eyeOpenness, pupilDiameter: sample.pupilDiameter)
+            }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] sample in
+                guard let self else { return }
+                self.latestSample = sample
+                self.heatmap?.addSample(sample.viewPoint)
+                self.trails.append(point: sample.viewPoint, timestamp: sample.timestamp)
+                self.sampleSubject.send(sample)
+            }
+            .store(in: &cancellables)
+    }
+
+    public func start() {
+        provider.start()
+    }
+
+    public func stop() {
+        provider.stop()
+        heatmap?.reset()
+        trails.reset()
+    }
+}

--- a/Sources/GazeTrackingKit/Support/GazeTypes.swift
+++ b/Sources/GazeTrackingKit/Support/GazeTypes.swift
@@ -1,0 +1,100 @@
+import Foundation
+import CoreGraphics
+import QuartzCore
+import simd
+
+public struct GazeSample: Sendable, Hashable, Codable {
+    public enum Validity: String, Codable {
+        case valid
+        case invalid
+        case limited
+    }
+
+    public let timestamp: TimeInterval
+    public let viewPoint: CGPoint
+    public let screenPoint: CGPoint?
+    public let features: SIMD8<Double>
+    public let validity: Validity
+    public let eyeOpenness: Double
+    public let pupilDiameter: Double?
+
+    public init(
+        timestamp: TimeInterval = CACurrentMediaTime(),
+        viewPoint: CGPoint,
+        screenPoint: CGPoint? = nil,
+        features: SIMD8<Double>,
+        validity: Validity = .valid,
+        eyeOpenness: Double = 1.0,
+        pupilDiameter: Double? = nil
+    ) {
+        self.timestamp = timestamp
+        self.viewPoint = viewPoint
+        self.screenPoint = screenPoint
+        self.features = features
+        self.validity = validity
+        self.eyeOpenness = eyeOpenness
+        self.pupilDiameter = pupilDiameter
+    }
+}
+
+public struct GazeCalibrationResult: Sendable, Codable {
+    public let coefficients: [Double]
+    public let regularization: Double
+    public let featureDimension: Int
+    public let rmsError: Double
+    public let medianError: Double
+    public let percentile95Error: Double
+
+    public init(
+        coefficients: [Double],
+        regularization: Double,
+        featureDimension: Int,
+        rmsError: Double,
+        medianError: Double,
+        percentile95Error: Double
+    ) {
+        self.coefficients = coefficients
+        self.regularization = regularization
+        self.featureDimension = featureDimension
+        self.rmsError = rmsError
+        self.medianError = medianError
+        self.percentile95Error = percentile95Error
+    }
+}
+
+public struct CalibrationPoint: Identifiable, Hashable, Codable {
+    public let id: Int
+    public let target: CGPoint
+    public let duration: TimeInterval
+
+    public init(id: Int, target: CGPoint, duration: TimeInterval = 0.4) {
+        self.id = id
+        self.target = target
+        self.duration = duration
+    }
+}
+
+public struct GazeStatistics: Sendable, Codable {
+    public let samples: Int
+    public let medianError: Double
+    public let percentile95Error: Double
+    public let rms: Double
+    public let angularMedian: Double
+    public let angular95: Double
+
+    public init(samples: Int, medianError: Double, percentile95Error: Double, rms: Double, angularMedian: Double, angular95: Double) {
+        self.samples = samples
+        self.medianError = medianError
+        self.percentile95Error = percentile95Error
+        self.rms = rms
+        self.angularMedian = angularMedian
+        self.angular95 = angular95
+    }
+}
+
+public enum GazeError: Error {
+    case insufficientSamples
+    case regressionFailure
+    case metalUnavailable
+    case permissionDenied
+}

--- a/Sources/GazeTrackingKit/Trails/TrailRenderer.swift
+++ b/Sources/GazeTrackingKit/Trails/TrailRenderer.swift
@@ -1,0 +1,52 @@
+import Combine
+import CoreGraphics
+import Foundation
+
+public final class TrailRenderer: ObservableObject {
+    public struct Segment: Identifiable, Sendable {
+        public let id = UUID()
+        public let points: [CGPoint]
+        public let createdAt: TimeInterval
+    }
+
+    @Published public private(set) var segments: [Segment] = []
+
+    public var duration: TimeInterval
+    public var maximumSamples: Int
+
+    private let queue = DispatchQueue(label: "com.eyetracker.trailrenderer")
+
+    public init(duration: TimeInterval = 3.5, maximumSamples: Int = 120) {
+        self.duration = duration
+        self.maximumSamples = maximumSamples
+    }
+
+    public func append(point: CGPoint, timestamp: TimeInterval) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            var segments = self.segments
+            if segments.isEmpty || (timestamp - (segments.last?.createdAt ?? 0) > 0.15) {
+                segments.append(Segment(points: [point], createdAt: timestamp))
+            } else {
+                var last = segments.removeLast()
+                var points = last.points
+                points.append(point)
+                if points.count > self.maximumSamples {
+                    points.removeFirst(points.count - self.maximumSamples)
+                }
+                segments.append(Segment(points: points, createdAt: last.createdAt))
+            }
+            let cutoff = timestamp - self.duration
+            segments.removeAll { $0.createdAt < cutoff }
+            DispatchQueue.main.async {
+                self.segments = segments
+            }
+        }
+    }
+
+    public func reset() {
+        DispatchQueue.main.async {
+            self.segments = []
+        }
+    }
+}

--- a/Sources/GazeUI/ViewModels/GazeViewModel.swift
+++ b/Sources/GazeUI/ViewModels/GazeViewModel.swift
@@ -1,0 +1,90 @@
+import Combine
+import CoreGraphics
+import Foundation
+import GazeTrackingKit
+
+@MainActor
+public final class GazeViewModel: ObservableObject {
+    @Published public var isTracking: Bool = false
+    @Published public var displayHeatmap: Bool = true
+    @Published public var displayTrails: Bool = true
+    @Published public var heatmapImage: CGImage?
+    @Published public var latestPoint: CGPoint = .zero
+    @Published public var calibrationProgress: Double = 0
+    @Published public var calibrationResult: GazeCalibrationResult?
+
+    public let session: GazeSession
+    private var cancellables = Set<AnyCancellable>()
+    private var heatmapTimer: AnyCancellable?
+
+    public init(session: GazeSession = GazeSession()) {
+        self.session = session
+        bind()
+    }
+
+    private func bind() {
+        session.$latestSample
+            .compactMap { $0 }
+            .sink { [weak self] sample in
+                self?.latestPoint = sample.viewPoint
+            }
+            .store(in: &cancellables)
+
+        if let heatmap = session.heatmap {
+            heatmap.$image
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] image in
+                    self?.heatmapImage = image
+                }
+                .store(in: &cancellables)
+        }
+
+        session.calibration.$progress
+            .assign(to: &$calibrationProgress)
+
+        session.calibration.$lastResult
+            .assign(to: &$calibrationResult)
+    }
+
+    public func toggleTracking() {
+        isTracking.toggle()
+        if isTracking {
+            session.start()
+            heatmapTimer = Timer.publish(every: 0.2, on: .main, in: .common)
+                .autoconnect()
+                .sink { [weak self] _ in
+                    self?.session.heatmap?.updateImage()
+                }
+        } else {
+            session.stop()
+            heatmapTimer?.cancel()
+            heatmapTimer = nil
+        }
+    }
+
+    public func beginCalibration(with publisher: AnyPublisher<GazeSample, Never>) {
+        session.calibration.beginCalibration(using: publisher)
+    }
+
+    public func finishCalibration() {
+        session.calibration.finishCalibration()
+    }
+
+    public func exportSamples(_ samples: [GazeSample], url: URL) throws {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(samples)
+        try data.write(to: url)
+    }
+
+    public func exportHeatmapGrid(to url: URL) throws {
+        guard let heatmap = session.heatmap else {
+            throw GazeError.metalUnavailable
+        }
+        let grid = heatmap.gridValues()
+        guard !grid.isEmpty else { return }
+        let csv = grid.map { row in
+            row.map { String(format: "%.5f", $0) }.joined(separator: ",")
+        }.joined(separator: "\n")
+        try csv.data(using: .utf8)?.write(to: url)
+    }
+}

--- a/Sources/GazeUI/Views/CalibrationFlowView.swift
+++ b/Sources/GazeUI/Views/CalibrationFlowView.swift
@@ -1,0 +1,71 @@
+import Combine
+import SwiftUI
+import GazeTrackingKit
+
+public struct CalibrationFlowView: View {
+    @ObservedObject private var manager: CalibrationManager
+    private let publisher: AnyPublisher<GazeSample, Never>
+
+    @State private var currentIndex: Int = 0
+    @State private var isRunning: Bool = false
+
+    public init(manager: CalibrationManager, publisher: AnyPublisher<GazeSample, Never>) {
+        self.manager = manager
+        self.publisher = publisher
+    }
+
+    public var body: some View {
+        VStack(spacing: 24) {
+            Text("Calibration")
+                .font(.largeTitle)
+                .bold()
+            ZStack {
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color.black.opacity(0.1))
+                GeometryReader { proxy in
+                    if isRunning, currentIndex < manager.points.count {
+                        let point = manager.points[currentIndex].target
+                        Circle()
+                            .fill(Color.accentColor)
+                            .frame(width: 24, height: 24)
+                            .position(x: proxy.size.width * point.x, y: proxy.size.height * point.y)
+                            .transition(.scale)
+                    }
+                }
+            }
+            .aspectRatio(16/9, contentMode: .fit)
+            ProgressView(value: manager.progress)
+            HStack {
+                Button("Start") {
+                    isRunning = true
+                    currentIndex = 0
+                    manager.beginCalibration(using: publisher)
+                    advance()
+                }
+                .disabled(isRunning)
+                Button("Finish") {
+                    isRunning = false
+                    manager.finishCalibration()
+                }
+                .disabled(!isRunning)
+            }
+        }
+        .padding()
+        .onReceive(manager.$progress) { progress in
+            guard isRunning else { return }
+            let total = Double(manager.points.count)
+            currentIndex = min(Int(progress * total), manager.points.count - 1)
+        }
+    }
+
+    private func advance() {
+        Task { @MainActor in
+            for idx in 0..<manager.points.count {
+                currentIndex = idx
+                try? await Task.sleep(nanoseconds: UInt64(manager.points[idx].duration * 1_000_000_000))
+            }
+            manager.finishCalibration()
+            isRunning = false
+        }
+    }
+}

--- a/Sources/GazeUI/Views/GazeDashboard.swift
+++ b/Sources/GazeUI/Views/GazeDashboard.swift
@@ -1,0 +1,26 @@
+import Combine
+import SwiftUI
+import GazeTrackingKit
+
+public struct GazeDashboard: View {
+    @StateObject private var viewModel: GazeViewModel
+    private let samplePublisher: AnyPublisher<GazeSample, Never>
+
+    public init(viewModel: GazeViewModel = GazeViewModel()) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+        samplePublisher = viewModel.session.samplePublisher
+    }
+
+    public var body: some View {
+        TabView {
+            LiveGazeView(viewModel: viewModel)
+                .tabItem { Label("Live", systemImage: "dot.radiowaves.left.and.right") }
+            MiniMapView(viewModel: viewModel)
+                .tabItem { Label("Mini Map", systemImage: "map") }
+            CalibrationFlowView(manager: viewModel.session.calibration, publisher: samplePublisher)
+                .tabItem { Label("Calibrate", systemImage: "target") }
+            MetricsView(manager: viewModel.session.calibration)
+                .tabItem { Label("Metrics", systemImage: "chart.bar.xaxis") }
+        }
+    }
+}

--- a/Sources/GazeUI/Views/LiveGazeView.swift
+++ b/Sources/GazeUI/Views/LiveGazeView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+import GazeTrackingKit
+
+public struct LiveGazeView: View {
+    @StateObject private var viewModel: GazeViewModel
+
+    public init(viewModel: GazeViewModel = GazeViewModel()) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    public var body: some View {
+        VStack(spacing: 16) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 16)
+                    .strokeBorder(.gray, lineWidth: 2)
+                    .background(Color.black.opacity(0.1))
+                    .overlay(alignment: .topLeading) {
+                        GeometryReader { proxy in
+                            if let image = viewModel.heatmapImage, viewModel.displayHeatmap {
+                                Image(decorative: image, scale: 1.0, orientation: .upMirrored)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: proxy.size.width, height: proxy.size.height)
+                                    .clipped()
+                            }
+                            if viewModel.displayTrails {
+                                TrailOverlay(trails: viewModel.session.trails)
+                            }
+                            Circle()
+                                .fill(Color.red)
+                                .frame(width: 12, height: 12)
+                                .position(x: proxy.size.width * viewModel.latestPoint.x, y: proxy.size.height * viewModel.latestPoint.y)
+                                .animation(.easeOut(duration: 0.1), value: viewModel.latestPoint)
+                        }
+                    }
+                    .aspectRatio(16/9, contentMode: .fit)
+            }
+            Toggle("Heatmap", isOn: $viewModel.displayHeatmap)
+            Toggle("Trails", isOn: $viewModel.displayTrails)
+            Button(action: viewModel.toggleTracking) {
+                Label(viewModel.isTracking ? "Stop" : "Start", systemImage: viewModel.isTracking ? "stop.fill" : "play.fill")
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(viewModel.isTracking ? Color.red : Color.accentColor)
+                    .foregroundStyle(.white)
+                    .cornerRadius(12)
+            }
+        }
+        .padding()
+    }
+}
+
+struct TrailOverlay: View {
+    @ObservedObject var trails: TrailRenderer
+
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            Canvas { context, size in
+                for segment in trails.segments {
+                    var path = Path()
+                    let points = segment.points
+                    guard let first = points.first else { continue }
+                    path.move(to: CGPoint(x: first.x * size.width, y: first.y * size.height))
+                    for point in points.dropFirst() {
+                        path.addLine(to: CGPoint(x: point.x * size.width, y: point.y * size.height))
+                    }
+                    let age = timeline.date.timeIntervalSinceReferenceDate - segment.createdAt
+                    let alpha = max(0, 1 - age / 3.5)
+                    context.stroke(path, with: .color(Color.blue.opacity(alpha)), lineWidth: 3)
+                }
+            }
+        }
+    }
+}

--- a/Sources/GazeUI/Views/MetricsView.swift
+++ b/Sources/GazeUI/Views/MetricsView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import GazeTrackingKit
+
+public struct MetricsView: View {
+    @ObservedObject private var manager: CalibrationManager
+
+    public init(manager: CalibrationManager) {
+        self.manager = manager
+    }
+
+    public var body: some View {
+        VStack(spacing: 16) {
+            Text("Accuracy Metrics")
+                .font(.title)
+                .bold()
+            if let result = manager.lastResult {
+                MetricRow(title: "Median px", value: result.medianError)
+                MetricRow(title: "95th px", value: result.percentile95Error)
+                MetricRow(title: "RMS", value: result.rmsError)
+            } else {
+                Text("Run calibration to view metrics.")
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+private struct MetricRow: View {
+    let title: String
+    let value: Double
+
+    var body: some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(String(format: "%.2f", value))
+                .bold()
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/Sources/GazeUI/Views/MiniMapView.swift
+++ b/Sources/GazeUI/Views/MiniMapView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import GazeTrackingKit
+
+public struct MiniMapView: View {
+    @ObservedObject private var viewModel: GazeViewModel
+
+    public init(viewModel: GazeViewModel) {
+        self.viewModel = viewModel
+    }
+
+    public var body: some View {
+        VStack(spacing: 16) {
+            Text("Mini Map")
+                .font(.title2)
+                .bold()
+            if let image = viewModel.heatmapImage {
+                Image(decorative: image, scale: 1.0)
+                    .resizable()
+                    .scaledToFit()
+                    .cornerRadius(12)
+                    .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.white.opacity(0.4), lineWidth: 1))
+                    .shadow(radius: 4)
+            } else {
+                Text("Heatmap will appear once tracking starts.")
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding()
+    }
+}

--- a/Tests/GazeTrackingKitTests/CalibrationTests.swift
+++ b/Tests/GazeTrackingKitTests/CalibrationTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import GazeTrackingKit
+
+final class CalibrationTests: XCTestCase {
+    func testPolynomialRegressorProducesCoefficients() throws {
+        let regressor = PolynomialRegressor(degree: 1, regularization: 1e-6)
+        let inputs = (0..<10).map { _ in SIMD8<Double>(repeating: 0.5) }
+        let outputs = (0..<10).map { _ in CGPoint(x: 0.3, y: 0.6) }
+        let result = try regressor.fit(inputs: inputs, outputs: outputs)
+        XCTAssertEqual(result.featureCount, regressor.designVector(from: inputs[0]).count)
+    }
+}

--- a/Tests/GazeTrackingKitTests/FilterTests.swift
+++ b/Tests/GazeTrackingKitTests/FilterTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import GazeTrackingKit
+
+final class FilterTests: XCTestCase {
+    func testOneEuroFilterSmoothsNoise() {
+        let filter = OneEuroFilter(minCutoff: 1.0, beta: 0.1, dCutoff: 1.0)
+        var output: [Double] = []
+        for i in 0..<60 {
+            let timestamp = Double(i) / 60.0
+            let noisy = sin(timestamp) + Double.random(in: -0.05...0.05)
+            output.append(filter.filter(value: noisy, timestamp: timestamp))
+        }
+        XCTAssertLessThan(output.last ?? 1, 1)
+    }
+
+    func testRobustOutlierFilterRejectsSpikes() {
+        var filter = RobustOutlierFilter(threshold: 2.5, windowSize: 20)
+        for value in stride(from: 0.0, through: 1.0, by: 0.05) {
+            XCTAssertTrue(filter.evaluate(value: value))
+        }
+        XCTAssertFalse(filter.evaluate(value: 100))
+    }
+}

--- a/Tests/GazeUITests/TrailRendererTests.swift
+++ b/Tests/GazeUITests/TrailRendererTests.swift
@@ -1,0 +1,18 @@
+import CoreGraphics
+import XCTest
+@testable import GazeTrackingKit
+
+final class TrailRendererTests: XCTestCase {
+    func testTrailRendererMaintainsDuration() {
+        let renderer = TrailRenderer(duration: 0.5, maximumSamples: 10)
+        let start = Date().timeIntervalSinceReferenceDate
+        renderer.append(point: CGPoint(x: 0.5, y: 0.5), timestamp: start)
+        renderer.append(point: CGPoint(x: 0.6, y: 0.6), timestamp: start + 0.1)
+        let expectation = XCTestExpectation(description: "segments updated")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            XCTAssertFalse(renderer.segments.isEmpty)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+}


### PR DESCRIPTION
## Summary
- add a multi-target Swift Package workspace with GazeTrackingKit, GazeUI, and the GazeLabPreviewer app entry point
- implement gaze providers, calibration, smoothing, heatmap/trail renderers, and SwiftUI dashboards with export utilities
- document build steps and add macOS GitHub Actions CI along with unit tests for the filters, calibration, and trail renderer

## Testing
- not run (Apple SDKs unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68def66ab08c8329a9d7e97010c9763a